### PR TITLE
Upgrade from .NET 5.x to .NET 7.0.7

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '7.0.x'
     
     - name: Build Application
       run: dotnet publish -c Release ./FullBodyMix/FullBodyMix.csproj

--- a/.idea/.idea.FullBodyMix/.idea/.gitignore
+++ b/.idea/.idea.FullBodyMix/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/.idea.FullBodyMix.iml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.FullBodyMix/.idea/indexLayout.xml
+++ b/.idea/.idea.FullBodyMix/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.FullBodyMix/.idea/vcs.xml
+++ b/.idea/.idea.FullBodyMix/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/FullBodyMix.Test/FullBodyMix.Test.csproj
+++ b/FullBodyMix.Test/FullBodyMix.Test.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>11</LangVersion>
 
     <IsPackable>false</IsPackable>
 
@@ -9,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FullBodyMix.sln
+++ b/FullBodyMix.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31702.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33801.468
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FullBodyMix", "FullBodyMix\FullBodyMix.csproj", "{E8EE609E-C33A-4DF0-A3D8-4EC9FB10294C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FullBodyMix", "FullBodyMix\FullBodyMix.csproj", "{E8EE609E-C33A-4DF0-A3D8-4EC9FB10294C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FullBodyMix.Test", "FullBodyMix.Test\FullBodyMix.Test.csproj", "{2C94213F-3A63-49F8-8EE3-BA93C88C064B}"
 EndProject

--- a/FullBodyMix.sln
+++ b/FullBodyMix.sln
@@ -10,6 +10,16 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0239E634-6FAA-465F-A45F-519E48C95377}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{0C6ADF74-49D6-4010-B926-D5D79ABF5CA1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{99FAC96A-285E-4975-8721-E981E2FE19E0}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\gh-pages.yml = .github\workflows\gh-pages.yml
 	EndProjectSection
 EndProject
 Global
@@ -32,5 +42,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D712CA2B-08E8-4980-9AA4-1DA61E2B7578}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0C6ADF74-49D6-4010-B926-D5D79ABF5CA1} = {0239E634-6FAA-465F-A45F-519E48C95377}
+		{99FAC96A-285E-4975-8721-E981E2FE19E0} = {0C6ADF74-49D6-4010-B926-D5D79ABF5CA1}
 	EndGlobalSection
 EndGlobal

--- a/FullBodyMix/FullBodyMix.csproj
+++ b/FullBodyMix/FullBodyMix.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Macross.Json.Extensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.10" PrivateAssets="all" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.7" PrivateAssets="all" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
   </ItemGroup>
 
 </Project>

--- a/FullBodyMix/Models/PerformanceParameters.cs
+++ b/FullBodyMix/Models/PerformanceParameters.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 
 namespace FullBodyMix.Models
 {
@@ -13,13 +12,11 @@ namespace FullBodyMix.Models
 		/// <summary>
 		/// How long is the pause until the next exercise?
 		/// </summary>
-		[JsonConverter(typeof(JsonTimeSpanConverter))]
 		public TimeSpan? RestTime { get; init; }
 
 		/// <summary>
 		/// How long should the exercise be performed for?
 		/// </summary>
-		[JsonConverter(typeof(JsonTimeSpanConverter))]
 		public TimeSpan? WorkTime { get; init; }
 	}
 }

--- a/FullBodyMix/Properties/launchSettings.json
+++ b/FullBodyMix/Properties/launchSettings.json
@@ -8,19 +8,14 @@
     }
   },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/FullBodyMix/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "FullBodyMix": {
       "commandName": "Project",
+      "commandLineArgs": "--pathbase=/FullBodyMix",
       "launchBrowser": true,
+      "launchUrl": "FullBodyMix",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/FullBodyMix/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "hotReloadEnabled": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
.NET 5 is no longer supported.

I had the hardest time getting debugging to work on a second computer.  It turns out the version of the NuGet packages have to match EXACTLY the version of the .NET SDK installed and it was only discovered once I was able to get at the full error response, since it almost worked and thus the error message wasn't presented front-and-center:

> HTTP Error 500.31 - Failed to load ASP.NET Core runtime
> Common solutions to this issue:
> The specified version of Microsoft.NetCore.App or Microsoft.AspNetCore.App was not found.
> Specific error detected by ANCM:
> You must install or update .NET to run this application. 
> - App: %USERPROFILE%\\.nuget\packages\microsoft.aspnetcore.components.webassembly.devserver\7.0.7\tools\blazor-devserver.dll
> - Architecture: x64
> - Framework: 'Microsoft.AspNetCore.App', version '7.0.7' (x64)
> - .NET location: C:\Program Files\dotnet\
>
> The following frameworks were found:
> - 6.0.16 at [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
> - 7.0.5 at [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
>
> Learn about framework resolution: https://aka.ms/dotnet/app-launch-failed
> To install missing framework, download: https://aka.ms/dotnet-core-applaunch?framework=Microsoft.AspNetCore.App&framework_version=7.0.7&arch=x64&rid=win10-x64
>
> Troubleshooting steps:
> - Check the system event log for error messages
> - Enable logging the application process' stdout messages
> - Attach a debugger to the application process and inspect
>
> For more information visit: https://go.microsoft.com/fwlink/?LinkID=2028526

The actual download link for the ASP.NET Core Runtime 7.0.7 x64 for Windows is:
https://download.visualstudio.microsoft.com/download/pr/754ad45c-5713-4bf7-8182-e82291e12d2f/4fbc681a6d28c7895b46940ebe573ae3/aspnetcore-runtime-7.0.7-win-x64.exe with a SHA512 checksum of `942b9b3eb8a6a676fe0da097f7694de5bb7de27b16d2b32ace5e95250eb6587a3a2271480ab4b70d874960140eb4a016cb62eaf768ad2fedab3b0bdd89cbe0df`

## Bonus points

JetBrains Rider has also been tested and can equally launch with the debugger, hit breakpoints, etc.