### PR TITLE
fix: publish the net7.0 folder for .NET 7

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,4 +23,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
            github_token: ${{ secrets.GITHUB_TOKEN }}
-           publish_dir: ./FullBodyMix/bin/Release/net5.0/publish/wwwroot/
+           publish_dir: ./FullBodyMix/bin/Release/net7.0/publish/wwwroot/


### PR DESCRIPTION
I missed this change in #2.